### PR TITLE
Removed '| -vv' from help line as causes errors

### DIFF
--- a/generate_reference.bat
+++ b/generate_reference.bat
@@ -59,7 +59,7 @@ goto tail
 echo.
 echo Creates and parses reference documentation for a GDScript based projects.
 echo.
-echo generate_reference $Path [-p dest] [-v | -vv] [--dry-run] [-i] [-V] [--doc-version]
+echo generate_reference $Path [-p dest] [-v] [--dry-run] [-i] [-V] [--doc-version]
 echo.
 echo   $Path  The path to the Godot project.    
 echo.


### PR DESCRIPTION
The help for generate_reference bat had [-v | -vv] which was causing
errors on some systems so it is now just [-v]